### PR TITLE
autodoc endpoint

### DIFF
--- a/coral/composer/routes.py
+++ b/coral/composer/routes.py
@@ -15,7 +15,7 @@ def prep_metrics(module):
     colors = {}
     for f in dir(module):
         func = getattr(module, f)
-        if inspect.isfunction(func) and inspect.getmodule(func) == module:
+        if not f.startswith('_') and inspect.isfunction(func) and inspect.getmodule(func) == module:
             color = '#{:02X}{:02X}{:02X}'.format(
                 random.randint(0,255),
                 random.randint(0,255),

--- a/coral/doc.py
+++ b/coral/doc.py
@@ -1,35 +1,40 @@
-"""
-quick stop-gap hardcoded endpoint for getting metric documentation
-"""
-
+import yaml
+import inspect
 from flask import Blueprint, jsonify
+from .metrics import user, comment, asset
 
 bp = Blueprint('doc', __name__, url_prefix='/doc')
 
+
+def prep_metrics(module):
+    """extract metric functions from a module"""
+    metrics = []
+    ignore = ['make'] # funcs to ignore
+    for f in dir(module):
+        func = getattr(module, f)
+        if not f.startswith('_') and f not in ignore \
+            and inspect.isfunction(func) \
+            and inspect.getmodule(func) == module:
+            # parse the metric metadata from its docstring
+            # should be yaml
+            meta = yaml.load(func.__doc__)
+            metric = {
+                'name': f,
+                'description': meta.get('description'),
+                'type': meta.get('type'),
+                'valid': meta.get('valid')
+            }
+            metrics.append(metric)
+        else:
+            continue
+    return metrics
+
+metrics = {
+    'user': prep_metrics(user),
+    'comment': prep_metrics(comment),
+    'asset': prep_metrics(asset),
+}
+
 @bp.route('/')
 def index():
-    return jsonify(metrics=[{
-        'name': 'diversity_score',
-        'entity': 'comment',
-        'description': 'Probability that a new reply would be from a new user.',
-        'type': 'float',
-        'valid': {
-            'type': 'range',
-            'min': 0,
-            'max': 1,
-            'min_inclusive': True,
-            'max_inclusive': True
-        }
-    }, {
-        'name': 'community_score',
-        'entity': 'user',
-        'description': 'Estimated number of likes a comment by this user will get.',
-        'type': 'float',
-        'valid': {
-            'type': 'range',
-            'min': 0,
-            'max': None,
-            'min_inclusive': True,
-            'max_inclusive': False
-        }
-    }])
+    return jsonify(metrics=metrics)

--- a/coral/metrics/__init__.py
+++ b/coral/metrics/__init__.py
@@ -1,5 +1,3 @@
-
-
 def apply_metric(obj, metric):
     """apply a metric to an object.
     returns the object's id with the labeled computed metric"""

--- a/coral/metrics/asset.py
+++ b/coral/metrics/asset.py
@@ -9,8 +9,17 @@ def make(data):
 
 
 def discussion_score(asset, k=1, theta=2):
-    """discussion score is the predicted discussion score for a new thread in the asset"""
-    X = np.array([max_thread_width(t) * max_thread_depth(t) for t in asset.threads])
+    """
+    description: Estimated number of comments this asset will get.
+    type: float
+    valid:
+        type: range
+        min: 0
+        max: null
+        min_inclusive: True
+        max_inclusive: False
+    """
+    X = np.array([_max_thread_width(t) * _max_thread_depth(t) for t in asset.threads])
     n = len(X)
 
     k = np.sum(X) + k
@@ -20,11 +29,20 @@ def discussion_score(asset, k=1, theta=2):
 
 
 def diversity_score(asset, alpha=2, beta=2):
-    """compute a diversity score for an asset's comments"""
+    """
+    description: Probability that a new reply would be from a new user.
+    type: float
+    valid:
+        type: range
+        min: 0
+        max: null
+        min_inclusive: True
+        max_inclusive: False
+    """
     X = set()
     n = 0
     for t in asset.threads:
-        users, n_comments = unique_participants(t)
+        users, n_comments = _unique_participants(t)
         X = X | users
         n += n_comments
     y = len(X)
@@ -32,34 +50,34 @@ def diversity_score(asset, alpha=2, beta=2):
     return beta_binomial_model(y, n, alpha, beta, 0.05)
 
 
-def max_thread_depth(thread):
+def _max_thread_depth(thread):
     """compute the length deepest branch of the thread"""
     if not thread.children:
         return 1
-    return 1 + max([max_thread_depth(reply) for reply in thread.children])
+    return 1 + max([_max_thread_depth(reply) for reply in thread.children])
 
 
-def max_thread_width(thread):
+def _max_thread_width(thread):
     """compute the widest breadth of the thread,
     that is the max number of replies a comment in the thread has received"""
     if not thread.children:
         return 0
     return max(
-        max([max_thread_width(reply) for reply in thread.children]),
+        max([_max_thread_width(reply) for reply in thread.children]),
         len(thread.children)
     )
 
 
-def count_replies(thread):
-    return 1 + sum(count_replies(r) for r in thread.children)
+def _count_replies(thread):
+    return 1 + sum(_count_replies(r) for r in thread.children)
 
 
-def unique_participants(thread):
+def _unique_participants(thread):
     """count unique participants and number of comments in a thread"""
     users = set([thread.user_id])
     n_replies = 1 + len(thread.children)
     for reply in thread.children:
-        r_users, r_replies = unique_participants(reply)
+        r_users, r_replies = _unique_participants(reply)
         n_replies += r_replies
         users = users | r_users
     return users, n_replies

--- a/coral/metrics/comment.py
+++ b/coral/metrics/comment.py
@@ -8,7 +8,16 @@ def make(data):
 
 
 def diversity_score(comment, alpha=2, beta=2):
-    """probability that a new reply would be from a new user"""
+    """
+    description: Probability that a new reply would be from a new user.
+    type: float
+    valid:
+        type: range
+        min: 0
+        max: 1
+        min_inclusive: True
+        max_inclusive: True
+    """
     seen_users = set()
 
     unique_participants = []

--- a/coral/metrics/user.py
+++ b/coral/metrics/user.py
@@ -9,7 +9,16 @@ def make(data):
 
 
 def community_score(user, k=1, theta=2):
-    """estimated number of likes a comment by this user will get"""
+    """
+    description: Estimated number of likes a comment by this user will get.
+    type: float
+    valid:
+        type: range
+        min: 0
+        max: null
+        min_inclusive: True
+        max_inclusive: False
+    """
     X = np.array([c.likes for c in user.comments])
     n = len(X)
 
@@ -20,7 +29,16 @@ def community_score(user, k=1, theta=2):
 
 
 def organization_score(user, alpha=2, beta=2):
-    """probability that a comment by this user will be an editor's pick"""
+    """
+    description: Probability that a comment by this user will be an editor's pick.
+    type: float
+    valid:
+        type: range
+        min: 0
+        max: 1
+        min_inclusive: True
+        max_inclusive: True
+    """
     # assume whether or not a comment is starred
     # is drawn from a binomial distribution parameterized by n, p
     # n is known, we want to estimate p
@@ -33,14 +51,32 @@ def organization_score(user, alpha=2, beta=2):
 
 
 def moderation_prob(user, alpha=2, beta=2):
-    """probability that a user's comment will be moderated"""
+    """
+    description: Probability that one of this user's comments will be moderated.
+    type: float
+    valid:
+        type: range
+        min: 0
+        max: 1
+        min_inclusive: True
+        max_inclusive: True
+    """
     y = sum(1 for c in user.comments if c.moderated)
     n = len(user.comments)
     return beta_binomial_model(y, n, alpha, beta, 0.05)
 
 
 def discussion_score(user, k=1, theta=2):
-    """estimated number of replies a comment by this user will get"""
+    """
+    description: Estimated number of replies a comment by this user will get.
+    type: float
+    valid:
+        type: range
+        min: 0
+        max: null
+        min_inclusive: True
+        max_inclusive: False
+    """
     X = np.array([len(c.children) for c in user.comments])
     n = len(X)
     return gamma_poission_model(X, n, k, theta, 0.05)


### PR DESCRIPTION
This PR adds an auto-documentation for metrics, exposed via a JSON endpoint at `/doc/`.

it has the following structure:

```
{
  metrics: {
    <entity name>: {
      description: string,
      datatype: string,
      valid: {
        type: string,
        min: float or null,
        max: float or null,
        min_inclusive: bool,
        max_inclusive: bool
      }
    }, ...
  }
}
```

the `valid` field will probably have different formats depending on its value for `type`, but for now, only `range` is supported