### PR TITLE
simple i18n support

### DIFF
--- a/coral/doc.py
+++ b/coral/doc.py
@@ -1,10 +1,10 @@
 import yaml
 import inspect
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 from .metrics import user, comment, asset
 
 bp = Blueprint('doc', __name__, url_prefix='/doc')
-
+supported_languages = ['en', 'de']
 
 types = {
     'nonnegative': {
@@ -24,7 +24,7 @@ types = {
 }
 
 
-def prep_metrics(module):
+def prep_metrics(module, lang):
     """extract metric functions from a module"""
     metrics = []
     ignore = ['make'] # funcs to ignore
@@ -33,12 +33,19 @@ def prep_metrics(module):
         if not f.startswith('_') and f not in ignore \
             and inspect.isfunction(func) \
             and inspect.getmodule(func) == module:
+
             # parse the metric metadata from its docstring
             # should be yaml
             meta = yaml.load(func.__doc__)
+
+            # extract localized description (if one exists)
+            # defaults to english, or None if there is no description at all.
+            desc = meta.get('description', {})
+            desc_local = desc.get(lang, desc.get('en'))
+
             metric = {
                 'name': f,
-                'description': meta.get('description'),
+                'description': desc_local,
                 'type': meta.get('type'),
                 'valid': types[meta.get('valid')]
             }
@@ -47,12 +54,15 @@ def prep_metrics(module):
             continue
     return metrics
 
-metrics = {
-    'user': prep_metrics(user),
-    'comment': prep_metrics(comment),
-    'asset': prep_metrics(asset),
-}
 
 @bp.route('/')
 def index():
+    lang = request.accept_languages.best_match(supported_languages, default='en')
+
+    metrics = {
+        'user': prep_metrics(user, lang),
+        'comment': prep_metrics(comment, lang),
+        'asset': prep_metrics(asset, lang),
+    }
+
     return jsonify(metrics=metrics)

--- a/coral/metrics/asset.py
+++ b/coral/metrics/asset.py
@@ -10,7 +10,9 @@ def make(data):
 
 def discussion_score(asset, k=1, theta=2):
     """
-    description: Estimated number of comments this asset will get.
+    description:
+        en: Estimated number of comments this asset will get.
+        de: Geschätzte Zahl der Kommentare dieser Vermögenswert erhalten.
     type: float
     valid: nonnegative
     """
@@ -25,7 +27,9 @@ def discussion_score(asset, k=1, theta=2):
 
 def diversity_score(asset, alpha=2, beta=2):
     """
-    description: Probability that a new reply would be from a new user.
+    description:
+        en: Probability that a new reply would be from a new user.
+        de: Wahrscheinlichkeit, dass eine neue Antwort würde von einem neuen Benutzer sein.
     type: float
     valid: probability
     """

--- a/coral/metrics/comment.py
+++ b/coral/metrics/comment.py
@@ -10,7 +10,9 @@ def make(data):
 
 def diversity_score(comment, alpha=2, beta=2):
     """
-    description: Probability that a new reply would be from a new user.
+    description:
+        en: Probability that a new reply would be from a new user.
+        de: Wahrscheinlichkeit, dass eine neue Antwort würde von einem neuen Benutzer sein.
     type: float
     valid: probability
     """
@@ -34,7 +36,9 @@ def diversity_score(comment, alpha=2, beta=2):
 
 def readability_scores(comment):
     """
-    description: A variety of readability scores (limited language support).
+    description:
+        en: A variety of readability scores (limited language support).
+        de: Eine Vielzahl von Lesbarkeit (begrenzte Sprachunterstützung).
     type: dict
     valid: nonnegative
     """

--- a/coral/metrics/user.py
+++ b/coral/metrics/user.py
@@ -10,7 +10,9 @@ def make(data):
 
 def community_score(user, k=1, theta=2):
     """
-    description: Estimated number of likes a comment by this user will get.
+    description:
+        en: Estimated number of likes a comment by this user will get.
+        de: Geschätzte Zahl der Gleichen Kommentar dieses Benutzers erhalten.
     type: float
     valid: nonnegative
     """
@@ -25,7 +27,9 @@ def community_score(user, k=1, theta=2):
 
 def organization_score(user, alpha=2, beta=2):
     """
-    description: Probability that a comment by this user will be an editor's pick.
+    description:
+        en: Probability that a comment by this user will be an editor's pick.
+        de: Wahrscheinlichkeit, dass ein Kommentar dieses Benutzers holen eines Editors können.
     type: float
     valid: probability
     """
@@ -42,7 +46,9 @@ def organization_score(user, alpha=2, beta=2):
 
 def moderation_prob(user, alpha=2, beta=2):
     """
-    description: Probability that one of this user's comments will be moderated.
+    description:
+        en: Probability that one of this user's comments will be moderated.
+        de: Wahrscheinlichkeit, dass eine der Kommentare des Nutzers, moderiert wird.
     type: float
     valid: probability
     """
@@ -53,7 +59,9 @@ def moderation_prob(user, alpha=2, beta=2):
 
 def discussion_score(user, k=1, theta=2):
     """
-    description: Estimated number of replies a comment by this user will get.
+    description:
+        en: Estimated number of replies a comment by this user will get.
+        de: Geschätzte Zahl der Antworten Kommentar dieses Benutzers erhalten.
     type: float
     valid: nonnegative
     """
@@ -64,7 +72,9 @@ def discussion_score(user, k=1, theta=2):
 
 def mean_likes_per_comment(user):
     """
-    description: Mean likes per comment.
+    description:
+        en: Mean likes per comment.
+        de: Durchschnitts Gleichen pro Kommentar.
     type: float
     valid: nonnegative
     """
@@ -73,7 +83,9 @@ def mean_likes_per_comment(user):
 
 def mean_replies_per_comment(user):
     """
-    description: Mean replies per comment.
+    description:
+        en: Mean replies per comment.
+        de: Durchschnitts Antworten per Kommentar.
     type: float
     valid: nonnegative
     """
@@ -82,7 +94,9 @@ def mean_replies_per_comment(user):
 
 def percent_replies(user):
     """
-    description: Percent of comments that are replies.
+    description:
+        en: Percent of comments that are replies.
+        de: Prozent der Kommentare, die Antworten gibt.
     type: float
     valid: probability
     """
@@ -91,7 +105,9 @@ def percent_replies(user):
 
 def mean_words_per_comment(user):
     """
-    description: Mean words per comment.
+    description:
+        en: Mean words per comment.
+        de: Durchschnitts Wörter pro Kommentar.
     type: float
     valid: nonnegative
     """


### PR DESCRIPTION
This PR adds very simple internationalization for the  documentation (`/doc/`) endpoint.

The docstrings for metric functions now looks like:

```python
    """
    description:
        en: Probability that a new reply would be from a new user.
        de: Wahrscheinlichkeit, dass eine neue Antwort würde von einem neuen Benutzer sein.
    type: float
    valid: probability
    """
```

i.e. the `description` field is now a dictionary with different language codes and translations of the description.

The documentation endpoint is the only endpoint returning text that a user will read, so (at this point at least) we don't need a more substantial i18n library in place.

The description language changes depending on the `Accept-Language` header in the request, e.g. for German descriptions:

    curl localhost:5001/doc/ --header "Accept-Language: de"

If a description is not available for a language, it falls back to the English description.

(the current translations might not be very good since they are from google translate :smile:)