### PR TITLE
Rolling metrics

### DIFF
--- a/atoll/pipeline.py
+++ b/atoll/pipeline.py
@@ -34,7 +34,7 @@ def branching(f):
     def decorated(self, *funcs):
         for func in funcs:
             assert ((not isinstance(func, type)) and callable(func)) or func is None, \
-                'Fork branches must be callable'
+                'Branches must be callable'
         branches = f(self, funcs)
         self.expected_kwargs += branches.expected_kwargs
         self.pipes.append((f.__name__, branches))
@@ -220,6 +220,16 @@ class Pipeline(Pipe):
         """like fork, but assumes bare functions are to be mapped"""
         return Branches(funcs, default='map')
 
+    @branching
+    def split(self, funcs):
+        """assumes input is tuples, each element is sent to a different branch"""
+        return Branches(funcs, default='to')
+
+    @branching
+    def splitMap(self, funcs):
+        """like split, but assumes bare functions are to be mapped"""
+        return Branches(funcs, default='map')
+
     # execution methods just take care of execution of the pipes
     # produced by the above composition/branching methods
 
@@ -288,6 +298,14 @@ class Pipeline(Pipe):
     @execution
     def _forkMap(self, funcs, input):
         return tuple(self.executor(self.funcproc(func)(input) for func in funcs))
+
+    @execution
+    def _split(self, funcs, input):
+        return tuple(self.executor(self.funcproc(f)(i) for f, i in zip(funcs, input)))
+
+    @execution
+    def _splitMap(self, funcs, input):
+        return tuple(self.executor(self.funcproc(f)(i) for f, i in zip(funcs, input)))
 
     def _serial(self, stream):
         return list(stream)

--- a/coral/__init__.py
+++ b/coral/__init__.py
@@ -38,7 +38,7 @@ coral.register_pipeline('/assets/score', score_assets)
 
 
 rolling_mean_users = Pipeline(name='rolling_mean_users')\
-    .forkMap(rolling.extract_latest, rolling.extract_history)\
+    .forkMap(rolling.extract_update, rolling.extract_history)\
     .split(score_users, None).flatMap()\
     .reduceByKey(rolling.rolling_mean)\
     .map(assign_id).map(prune_none)

--- a/coral/__init__.py
+++ b/coral/__init__.py
@@ -37,12 +37,12 @@ score_assets = Pipeline(name='score_assets')\
 coral.register_pipeline('/assets/score', score_assets)
 
 
-rolling_mean_users = Pipeline(name='rolling_mean_users')\
+rolling_score_users = Pipeline(name='rolling_score_users')\
     .forkMap(rolling.extract_update, rolling.extract_history)\
     .split(score_users, None).flatMap()\
-    .reduceByKey(rolling.rolling_mean)\
+    .reduceByKey(rolling.rolling_score)\
     .map(assign_id).map(prune_none)
-coral.register_pipeline('/users/rolling', rolling_mean_users)
+coral.register_pipeline('/users/rolling', rolling_score_users)
 
 
 from .doc import bp as doc_bp

--- a/coral/__init__.py
+++ b/coral/__init__.py
@@ -1,6 +1,6 @@
 from functools import partial
 from atoll import Atoll, Pipeline
-from .metrics import user, comment, asset, apply_metric, merge_dicts, assign_id, prune_none, aggregates
+from .metrics import user, comment, asset, apply_metric, merge_dicts, assign_id, prune_none, aggregates, rolling
 
 
 coral = Atoll()
@@ -16,8 +16,8 @@ score_users = Pipeline(name='score_users')\
         partial(apply_metric, metric=user.mean_words_per_comment),
         partial(apply_metric, metric=user.percent_replies),
     ).flatMap()\
-    .reduceByKey(merge_dicts).map(assign_id).map(prune_none).to(aggregates)
-coral.register_pipeline('/users/score', score_users)
+    .reduceByKey(merge_dicts)
+coral.register_pipeline('/users/score', Pipeline(name='score_users').to(score_users).map(assign_id).map(prune_none).to(aggregates))
 
 score_comments = Pipeline(name='score_comments')\
     .forkMap(
@@ -37,6 +37,13 @@ score_assets = Pipeline(name='score_assets')\
 coral.register_pipeline('/assets/score', score_assets)
 
 
-# TODO/TEMP documentation endpoint
+rolling_mean_users = Pipeline(name='rolling_mean_users')\
+    .forkMap(rolling.extract_latest, rolling.extract_history)\
+    .split(score_users, None).flatMap()\
+    .reduceByKey(rolling.rolling_mean)\
+    .map(assign_id).map(prune_none)
+coral.register_pipeline('/users/rolling', rolling_mean_users)
+
+
 from .doc import bp as doc_bp
 coral.blueprints.append(doc_bp)

--- a/coral/metrics/asset.py
+++ b/coral/metrics/asset.py
@@ -79,7 +79,6 @@ def reconstruct_threads(asset):
     """reconstruct threads structure from a flat list of comments"""
     id = asset['_id']
     parents = defaultdict(list)
-    print(asset)
     for c in asset['comments']:
         p_id = c['parent_id'] # TODO mongo ids y/n?
         if isinstance(p_id, float) and math.isnan(p_id):

--- a/coral/metrics/rolling.py
+++ b/coral/metrics/rolling.py
@@ -1,0 +1,40 @@
+def extract_history(input):
+    """extract the past metrics"""
+    prev = input['prev']
+    prev['prev'] = True
+    return input['_id'], prev
+
+
+def extract_latest(input):
+    """extract the update data, from which we compute new metrics"""
+    latest = input['latest']
+    latest['_id'] = input['_id']
+    return latest
+
+
+def rolling_mean(d1, d2, alpha=0.5):
+    """computes rolling means, decaying the past by alpha.
+    the past metrics are identified by the `prev` key.
+    any keys present in the update dict that are not in the past
+    dict are carried over."""
+
+    # figure out which dict is the previous metrics
+    if 'prev' in d1 and d1['prev']:
+        prev, update = d1, d2
+    else:
+        prev, update = d2, d1
+    del prev['prev']
+
+    new = {}
+    for k, v in prev.items():
+        if k in update:
+            new[k] = v + (alpha * (update[k] - v))
+        else:
+            new[k] = v
+
+    for k in set(update.keys()) - set(new.keys()):
+        new[k] = update[k]
+
+    return new
+
+

--- a/coral/metrics/rolling.py
+++ b/coral/metrics/rolling.py
@@ -5,11 +5,11 @@ def extract_history(input):
     return input['_id'], prev
 
 
-def extract_latest(input):
+def extract_update(input):
     """extract the update data, from which we compute new metrics"""
-    latest = input['latest']
-    latest['_id'] = input['_id']
-    return latest
+    update = input['update']
+    update['_id'] = input['_id']
+    return update
 
 
 def rolling_mean(d1, d2, alpha=0.5):

--- a/coral/tests/test_service.py
+++ b/coral/tests/test_service.py
@@ -78,6 +78,46 @@ class ServiceTest(unittest.TestCase):
             for k, t in expected.items():
                 self.assertTrue(isinstance(result[k], t))
 
+    def test_users_rolling(self):
+        data = [{
+            '_id': 0,
+            'latest': {
+                'comments': [self._make_comment()]
+            },
+            'prev': {
+                'community_score': 1.,
+                'discussion_score': 1.,
+                'moderation_prob': 0.,
+                'organization_score': 1.
+            }
+        }, {
+            '_id': 1,
+            'latest': {
+                'comments': [self._make_comment()]
+            },
+            'prev': {
+                'community_score': 1.,
+                'discussion_score': 1.,
+                'moderation_prob': 0.,
+                'organization_score': 1.
+            }
+        }]
+
+        resp = self._call_pipeline('users/rolling', data)
+        self.assertEquals(resp.status_code, 200)
+
+        expected = {
+            'id': int,
+            'community_score': float,
+            'discussion_score': float,
+            'moderation_prob': float,
+            'organization_score': float
+        }
+        resp_json = json.loads(resp.data.decode('utf-8'))
+        for result in resp_json['results']:
+            for k, t in expected.items():
+                self.assertTrue(isinstance(result[k], t))
+
     def test_comments_score(self):
         data = [
             self._make_comment(),

--- a/coral/tests/test_service.py
+++ b/coral/tests/test_service.py
@@ -81,7 +81,7 @@ class ServiceTest(unittest.TestCase):
     def test_users_rolling(self):
         data = [{
             '_id': 0,
-            'latest': {
+            'update': {
                 'comments': [self._make_comment()]
             },
             'prev': {
@@ -92,7 +92,7 @@ class ServiceTest(unittest.TestCase):
             }
         }, {
             '_id': 1,
-            'latest': {
+            'update': {
                 'comments': [self._make_comment()]
             },
             'prev': {

--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,8 @@ The provided `run` script makes it easy to get this up and running. Install Dock
 
 ## (Py)Spark support
 
+NOTE: Spark support is EXPERIMENTAL - some `atoll` pipeline operators may not be supported by Spark.
+
 `atoll` can run its pipelines either on a single computer with multiprocessing or across a Spark cluster.
 
 To run a pipeline across a Spark cluster you must have a Spark cluster managed by Zookeeper ([see here](https://github.com/frnsys/docker-mesos-pyspark-hdfs) for some Docker files to get you going, [see here](http://spaceandtim.es/code/mesos_spark_zookeeper_hdfs_docker) for more details).

--- a/tests/test_branching.py
+++ b/tests/test_branching.py
@@ -52,3 +52,13 @@ class BranchingPipelineTests(unittest.TestCase):
         p = Pipeline().forkMap(double, double)
         out = p([1,2,3,4])
         self.assertEqual(out, ([2,4,6,8], [2,4,6,8]))
+
+    def test_split(self):
+        p = Pipeline().split(double, double)
+        out = p([[1,2], [3,4]])
+        self.assertEqual(out, ([1,2,1,2], [3,4,3,4]))
+
+    def test_split_map(self):
+        p = Pipeline().splitMap(double, double)
+        out = p([[1,2], [3,4]])
+        self.assertEqual(out, ([2,4], [6,8]))


### PR DESCRIPTION
This PR adds an endpoint `/users/rolling` where rolling metrics can be computed for users. This makes it so that we do not have to submit ever-growing payloads to compute metrics for users.

It accepts data in the format:

```
[{
    '_id': 1,
    'update': {
        'comments': [...],
        # etc
    },
    'prev': {
        'community_score': 0.55,
        'discussion_score': 0.145,
        ...
    }
}, ...]]
```

and it returns the updated metrics, e.g.

```
{'results': [{
    'id': 1,
    'community_score': 0.62,
    'discussion_score': 0.16
}, ...]}
```

Metrics that weren't available in the `prev` metrics, but were computed from the `update`, are included in the returned metrics.

The rolling metric calculation itself may need some adjustment later.