### PR TITLE
New distributed computing system

### DIFF
--- a/atoll/config.py
+++ b/atoll/config.py
@@ -9,11 +9,7 @@ import yaml
 conf = {
     'worker_broker': 'amqp://guest:guest@localhost/',
     'worker_backend': 'amqp',
-
-    # this must be a _prebuilt_ spark archive, i.e. a spark binary package
-    # you can build it and host it yourself if you like.
-    'spark_binary': 'http://d3kbcqa49mib13.cloudfront.net/spark-1.5.0-bin-hadoop2.6.tgz',
-    'zookeeper_host': '172.17.0.1:2181'
+    'executor_host': '127.0.0.1:8786'
 }
 
 user_conf_path = os.environ.get('ATOLL_CONF', None)

--- a/atoll/distrib.py
+++ b/atoll/distrib.py
@@ -1,57 +1,98 @@
 from itertools import chain
-from functools import partial
 from distributed import Executor
-from atoll.pipes import Branches
+from atoll.utility import prep_func
 from atoll.config import EXECUTOR_HOST
 
 
-def prep_func(pipe, **kwargs):
-    """
-    Prepares a pipe's function or branches
-    by returning a partial function with its kwargs.
-    """
-    if isinstance(pipe, Branches):
-        return [prep_func(b) for b in pipe.branches]
-    else:
-        kwargs_ = {}
-        for key in pipe.expected_kwargs:
-            try:
-                kwargs_[key] = kwargs[key]
-            except KeyError:
-                raise KeyError('Missing expected keyword argument: {}'.format(key))
-        return partial(pipe._func, **kwargs_)
+def compute_pipeline(pipes, input, **kwargs):
+    """computes a pipeline in a distributed fashion"""
+    exc = Executor(EXECUTOR_HOST)
+    for op, pipe in pipes:
+        f = prep_func(pipe, **kwargs)
+        input = globals()[op](exc, f, input)
+    return _get_results(exc, input)
 
 
-def _kv(f):
-    def kv_func(p):
-        """helper to apply function `f` to value `v`"""
-        k, v = p
-        return k, f(v)
-    return kv_func
+def to(executor, f, input):
+    f = _to(f)
+    return executor.submit(f, input)
 
-def _unpack(f):
-    def decorated(input):
-        if not isinstance(input, tuple):
-            input = (input,)
-        return f(*input)
-    return decorated
 
 def map(executor, f, input):
     f = _unpack(f)
     return executor.map(f, input)
 
+
 def mapValues(executor, f, input):
     f = _kv(f)
     return executor.map(f, input)
+
 
 def flatMap(executor, f, input):
     fmap = lambda input: [result for result in chain(*input)]
     f = _unpack(f)
     return executor.submit(fmap, executor.map(f, input))
 
+
 def flatMapValues(executor, f, input):
     fmap = lambda input: [result for result in chain(*[[(k, v) for v in vs] for k, vs in input])]
     return executor.submit(fmap, mapValues(executor, f, input))
+
+
+def fork(executor, fs, input):
+    return [executor.submit(f, input) for f in fs]
+
+
+def forkMap(executor, fs, input):
+    # TODO for some reason the executor thinks each function is identical
+    # wrapping the function in this way solves the problem
+    return [executor.submit(_identity(f), input) for f in fs]
+
+
+def reduce(executor, f, input):
+    f = _reduce(f)
+    return executor.submit(f, input)
+
+
+def reduceByKey(executor, f, input):
+    f = _reduceByKey(f)
+    return executor.submit(f, input)
+
+
+def split(executor, fs, input):
+    return [executor.submit(f, i) for f, i in zip(fs, input)]
+
+
+def splitMap(executor, fs, input):
+    return [executor.submit(f, i) for f, i in zip(fs, input)]
+
+
+def _get_results(executor, input):
+    """retrieves distributed results, causing the pipeline to execute"""
+    if isinstance(input, list):
+        return executor.gather(input)
+    elif isinstance(input, tuple):
+        return [_get_results(executor, i) for i in input]
+    else:
+        return input.result()
+
+
+def _kv(f):
+    """helper to apply function `f` to value `v`"""
+    def kv_func(p):
+        k, v = p
+        return k, f(v)
+    return kv_func
+
+
+def _unpack(f):
+    """to unpack arguments"""
+    def decorated(input):
+        if not isinstance(input, tuple):
+            input = (input,)
+        return f(*input)
+    return decorated
+
 
 def _reduce(f):
     def reduce_func(input):
@@ -61,9 +102,6 @@ def _reduce(f):
         return output
     return reduce_func
 
-def reduce(executor, f, input):
-    f = _reduce(f)
-    return executor.submit(f, input)
 
 def _reduceByKey(f):
     def reduce_func(input):
@@ -76,34 +114,9 @@ def _reduceByKey(f):
         return list(results.items())
     return reduce_func
 
-def reduceByKey(executor, f, input):
-    f = _reduceByKey(f)
-    return executor.submit(f, input)
-
-def compute_pipeline(pipes, input, **kwargs):
-    exc = Executor(EXECUTOR_HOST)
-    for op, pipe in pipes:
-        f = prep_func(pipe, **kwargs)
-        input = globals()[op](exc, f, input)
-    return _get_results(exc, input)
-
-def _get_results(executor, input):
-    if isinstance(input, list):
-        return executor.gather(input)
-    elif isinstance(input, tuple):
-        return [_get_results(executor, i) for i in input]
-    else:
-        return input.result()
-
-def split(executor, fs, input):
-    return [executor.submit(f, i) for f, i in zip(fs, input)]
-
-def splitMap(executor, fs, input):
-    return [executor.submit(f, i) for f, i in zip(fs, input)]
 
 def _to(f):
     def func(input):
-        print('CALLED WITH INPUT', input)
         if not isinstance(input, tuple):
             input = (input,)
         else:
@@ -115,17 +128,8 @@ def _to(f):
                 else:
                     args.append(arg)
             input = args
-        print('CALLING', f)
-        print('WITH INPUTS', input)
         return f(*input)
     return func
-
-def to(executor, f, input):
-    f = _to(f)
-    return executor.submit(f, input)
-
-def fork(executor, fs, input):
-    return [executor.submit(f, input) for f in fs]
 
 
 def _identity(f):
@@ -134,30 +138,3 @@ def _identity(f):
         return f(input)
     return func
 
-def forkMap(executor, fs, input):
-    # TODO for some reason the executor thinks each function is identical
-    # wrapping the function in this way solves the problem
-    return [executor.submit(_identity(f), input) for f in fs]
-
-
-if __name__ == '__main__':
-    executor = Executor(EXECUTOR_HOST)
-
-    # basics
-    def square(x):
-        x,y=x
-        return x**2, y
-
-    def neg(x):
-        x,y=x
-        return -x
-
-    # inp = [1,2,3,4]
-    inp = [(1,1),(2,1),(3,1),(4,1)]
-
-    A = executor.map(square, inp)
-    B = executor.map(neg, A)
-    C = executor.submit(sum, B)
-    print(C.result())
-
-    print(executor.gather(B))

--- a/atoll/distrib.py
+++ b/atoll/distrib.py
@@ -1,27 +1,165 @@
-from atoll.config import ZOOKEEPER_HOST, SPARK_BINARY
+# from atoll.config import EXECUTOR_HOST
+from functools import partial
+from itertools import chain
+from distributed import Executor
+from atoll.pipes import Branches
 
-try:
-    import pyspark
-except ImportError:
-    pyspark = None
-
-_SPARK_CTX = None
-
-
-def spark_context(pipeline_name):
-    """return the app's spark context; make one if necessary"""
-    global _SPARK_CTX
-    if pyspark is None:
-        raise ImportError('`pyspark` is required to run a distributed pipeline.')
-
-    if _SPARK_CTX is None:
-        conf = pyspark.SparkConf()
-        conf.setMaster('mesos://zk://{}/mesos'.format(ZOOKEEPER_HOST))
-        conf.setAppName(pipeline_name)
-        conf.set('spark.executor.uri', SPARK_BINARY)
-        _SPARK_CTX = pyspark.SparkContext(conf=conf)
-    return _SPARK_CTX
+EXECUTOR_HOST = '127.0.0.1:8786'
 
 
-def is_rdd(obj):
-    return isinstance(obj, pyspark.rdd.RDD)
+def prep_func(pipe, **kwargs):
+    """
+    Prepares a pipe's function or branches
+    by returning a partial function with its kwargs.
+    """
+    if isinstance(pipe, Branches):
+        return [prep_func(b) for b in pipe.branches]
+    else:
+        kwargs_ = {}
+        for key in pipe.expected_kwargs:
+            try:
+                kwargs_[key] = kwargs[key]
+            except KeyError:
+                raise KeyError('Missing expected keyword argument: {}'.format(key))
+        return partial(pipe._func, **kwargs_)
+
+
+def _kv(f):
+    def kv_func(p):
+        """helper to apply function `f` to value `v`"""
+        k, v = p
+        return k, f(v)
+    return kv_func
+
+def _unpack(f):
+    def decorated(input):
+        if not isinstance(input, tuple):
+            input = (input,)
+        return f(*input)
+    return decorated
+
+def map(executor, f, input):
+    f = _unpack(f)
+    return executor.map(f, input)
+
+def mapValues(executor, f, input):
+    f = _kv(f)
+    return executor.map(f, input)
+
+def flatMap(executor, f, input):
+    fmap = lambda input: [result for result in chain(*input)]
+    f = _unpack(f)
+    return executor.submit(fmap, executor.map(f, input))
+
+def flatMapValues(executor, f, input):
+    fmap = lambda input: [result for result in chain(*[[(k, v) for v in vs] for k, vs in input])]
+    return executor.submit(fmap, mapValues(executor, f, input))
+
+def _reduce(f):
+    def reduce_func(input):
+        output = input[0]
+        for i in input[1:]:
+            output = f(output, i)
+        return output
+    return reduce_func
+
+def reduce(executor, f, input):
+    f = _reduce(f)
+    return executor.submit(f, input)
+
+def _reduceByKey(f):
+    def reduce_func(input):
+        results = {}
+        for k, v in input:
+            try:
+                results[k] = f(results[k], v)
+            except KeyError:
+                results[k] = v
+        return list(results.items())
+    return reduce_func
+
+def reduceByKey(executor, f, input):
+    f = _reduceByKey(f)
+    return executor.submit(f, input)
+
+def compute_pipeline(pipes, input, **kwargs):
+    exc = Executor(EXECUTOR_HOST)
+    for op, pipe in pipes:
+        f = prep_func(pipe, **kwargs)
+        input = globals()[op](exc, f, input)
+    return _get_results(exc, input)
+
+def _get_results(executor, input):
+    if isinstance(input, list):
+        return executor.gather(input)
+    elif isinstance(input, tuple):
+        return [_get_results(executor, i) for i in input]
+    else:
+        return input.result()
+
+def split(executor, fs, input):
+    return [executor.submit(f, i) for f, i in zip(fs, input)]
+
+def splitMap(executor, fs, input):
+    return [executor.submit(f, i) for f, i in zip(fs, input)]
+
+def _to(f):
+    def func(input):
+        print('CALLED WITH INPUT', input)
+        if not isinstance(input, tuple):
+            input = (input,)
+        else:
+            # flatten nested tuples
+            args = []
+            for arg in input:
+                if isinstance(arg, tuple):
+                    args.extend(arg)
+                else:
+                    args.append(arg)
+            input = args
+        print('CALLING', f)
+        print('WITH INPUTS', input)
+        return f(*input)
+    return func
+
+def to(executor, f, input):
+    f = _to(f)
+    return executor.submit(f, input)
+
+def fork(executor, fs, input):
+    return [executor.submit(f, input) for f in fs]
+
+
+def _identity(f):
+    # a hack to fix issues with forkMap, see forkMap
+    def func(input):
+        return f(input)
+    return func
+
+def forkMap(executor, fs, input):
+    # TODO for some reason the executor thinks each function is identical
+    # wrapping the function in this way solves the problem
+    return [executor.submit(_identity(f), input) for f in fs]
+
+
+if __name__ == '__main__':
+    executor = Executor(EXECUTOR_HOST)
+
+    # basics
+    def square(x):
+        x,y=x
+        return x**2, y
+
+    def neg(x):
+        x,y=x
+        return -x
+
+    # inp = [1,2,3,4]
+    inp = [(1,1),(2,1),(3,1),(4,1)]
+
+    A = executor.map(square, inp)
+    B = executor.map(neg, A)
+    C = executor.submit(sum, B)
+    print(C.result())
+
+    print(executor.gather(B))

--- a/atoll/distrib.py
+++ b/atoll/distrib.py
@@ -1,10 +1,8 @@
-# from atoll.config import EXECUTOR_HOST
-from functools import partial
 from itertools import chain
+from functools import partial
 from distributed import Executor
 from atoll.pipes import Branches
-
-EXECUTOR_HOST = '127.0.0.1:8786'
+from atoll.config import EXECUTOR_HOST
 
 
 def prep_func(pipe, **kwargs):

--- a/atoll/pipeline.py
+++ b/atoll/pipeline.py
@@ -5,6 +5,7 @@ from itertools import chain
 from functools import partial
 from joblib import Parallel, delayed
 from atoll import distrib
+from atoll.utility import prep_func
 from atoll.pipes import Pipe, Branches
 
 
@@ -40,23 +41,6 @@ def branching(f):
         self.pipes.append((f.__name__, branches))
         return self
     return decorated
-
-
-def prep_func(pipe, **kwargs):
-    """
-    Prepares a pipe's function or branches
-    by returning a partial function with its kwargs.
-    """
-    if isinstance(pipe, Branches):
-        return [prep_func(b) for b in pipe.branches]
-    else:
-        kwargs_ = {}
-        for key in pipe.expected_kwargs:
-            try:
-                kwargs_[key] = kwargs[key]
-            except KeyError:
-                raise KeyError('Missing expected keyword argument: {}'.format(key))
-        return partial(pipe._func, **kwargs_)
 
 
 def kv_func(f, k, v):

--- a/atoll/pipeline.py
+++ b/atoll/pipeline.py
@@ -4,8 +4,8 @@ from hashlib import md5
 from itertools import chain
 from functools import partial
 from joblib import Parallel, delayed
+from atoll import distrib
 from atoll.pipes import Pipe, Branches
-from atoll.distrib import spark_context, is_rdd
 
 
 logger = logging.getLogger(__name__)
@@ -58,9 +58,11 @@ def prep_func(pipe, **kwargs):
                 raise KeyError('Missing expected keyword argument: {}'.format(key))
         return partial(pipe._func, **kwargs_)
 
+
 def kv_func(f, k, v):
     """helper to apply function `f` to value `v`"""
     return k, f(v)
+
 
 def execution(f):
     """decorates the function which executes a corresponding pipe"""
@@ -81,7 +83,10 @@ class Pipeline(Pipe):
         Used if the pipeline is nested in another.
         This prevents nested pipelines from running their own parallel processes.
         """
-        return self(input, distributed=distributed, nested=True, **kwargs)
+        print('CALLED FUNC')
+        out = self(input, distributed=distributed, nested=True, **kwargs)
+        print("OUTPUT", out)
+        return out
 
     def __call__(self, input, n_jobs=1, serial=False, distributed=False, validate=False, nested=False, **kwargs):
         """
@@ -93,34 +98,7 @@ class Pipeline(Pipe):
             self.validate(input, n_jobs=n_jobs)
 
         if distributed:
-            rdd = input
-            # create RDD from input if necessary
-            if not is_rdd(input):
-                sc = spark_context(self.name)
-                n_jobs = None if n_jobs <= 0 else n_jobs
-                rdd = sc.parallelize(input, n_jobs)
-
-            # run the pipes
-            for op, pipe in self.pipes:
-                func = prep_func(pipe, **kwargs)
-                if op == 'fork':
-                    # cache the current RDD
-                    rdd.cache()
-
-                    # bleh, build out each branch as an RDD,
-                    # then we have to (afaik) collect their results
-                    # then build a new rdd out of that
-                    rdds = [branch(rdd, distributed=True) for branch in func]
-                    rdd = sc.parallelize([r.collect() if is_rdd(r) else r for r in rdds], n_jobs)
-                elif op == 'to':
-                    # the `to` operation requires the resulting dataset
-                    # so we have to collect the results (if necessary)
-                    # we don't create the new RDD, we'll let the next
-                    # iteration do so if necessary
-                    rdd = self._to(pipe, rdd.collect() if is_rdd(rdd) else rdd, **kwargs)
-                else:
-                    rdd = getattr(rdd, op)(func)
-            return rdd.collect() if is_rdd(rdd) else rdd
+            return distrib.compute_pipeline(self.pipes, input, **kwargs)
 
         else:
             if nested or serial:

--- a/atoll/utility.py
+++ b/atoll/utility.py
@@ -1,0 +1,19 @@
+from functools import partial
+from atoll.pipes import Branches
+
+
+def prep_func(pipe, **kwargs):
+    """
+    Prepares a pipe's function or branches
+    by returning a partial function with its kwargs.
+    """
+    if isinstance(pipe, Branches):
+        return [prep_func(b) for b in pipe.branches]
+    else:
+        kwargs_ = {}
+        for key in pipe.expected_kwargs:
+            try:
+                kwargs_[key] = kwargs[key]
+            except KeyError:
+                raise KeyError('Missing expected keyword argument: {}'.format(key))
+        return partial(pipe._func, **kwargs_)

--- a/deploy/playbooks/group_vars/all.yml
+++ b/deploy/playbooks/group_vars/all.yml
@@ -5,7 +5,6 @@ remote_user: ubuntu
 web_group: www-data
 worker_broker: amqp://guest:guest@localhost/
 worker_backend: amqp
-spark_binary: http://d3kbcqa49mib13.cloudfront.net/spark-1.5.0-bin-hadoop2.6.tgz
-zookeeper_host: 172.17.0.1:2181
+executor_host: 127.0.0.1:8786
 config_path: /var/www/atoll/config.yml
 host_name: localhost

--- a/deploy/playbooks/roles/app/templates/config.yml
+++ b/deploy/playbooks/roles/app/templates/config.yml
@@ -1,4 +1,3 @@
 worker_broker: '{{ worker_broker }}'
 worker_backend: '{{ worker_backend }}'
-spark_binary: '{{ spark_binary }}'
-zookeeper_host: '{{ zookeeper_host }}'
+executor_host: '{{ executor_host }}'

--- a/docs/microservice.rst
+++ b/docs/microservice.rst
@@ -50,11 +50,7 @@ You can provide a configuration for the microservice in a YAML file. The default
 
     worker_broker: amqp://guest:guest@localhost/
     worker_backend: amqp
-
-    # this must be a _prebuilt_ spark archive, i.e. a spark binary package
-    # you can build it and host it yourself if you like.
-    spark_binary: http://d3kbcqa49mib13.cloudfront.net/spark-1.5.0-bin-hadoop2.6.tgz
-    zookeeper_host: 172.17.0.1:2181
+    executor_host: 127.0.0.1:8786
 
 The important option here is the ``worker_broker`` option, which specifies the connection string for the Celery broker.
 

--- a/docs/pipelines.rst
+++ b/docs/pipelines.rst
@@ -199,20 +199,9 @@ Pipes and branches in a pipelines can be executed in parallel (using multiproces
     results_a, results_b = branching_pipeline(data, n_jobs=2)
     # >>> [6,9], [1,1]
 
-Pipes and branches can also be executed in a distributed fashion across a cluster by using (Py)Spark.
+Pipes and branches can also be executed in a distributed fashion across a cluster using the ``distributed`` library.
 
-Currently, only a Mesos cluster managed by Zookeeper is supported.
-
-`See here <https://github.com/frnsys`_ for some Docker files to help you setup a cluster to work with (`see here <http://spaceandtim.es/code/mesos_spark_zookeeper_hdfs_docker>`_ for more details)).
-
-You will likely also want to specify your own configuration. See :ref:`configuration`.
-
-Note that if you are using Docker for your cluster, you may need to export the following env variables before running your pipeline:
-
-.. code-block:: bash
-
-    export LIBPROCESS_IP=$(ifconfig docker0 | grep 'inet addr:' | cut -d: -f2 | awk '{print $1}')
-    export PYSPARK_PYTHON=/usr/bin/python3
+You will likely also want to specify your own configuration. See :ref:`configuration`. Then main configuration option is where the executor host is (by default, it assumes ``127.0.0.1:8786``).
 
 Then, to run a pipeline on the cluster, just pass ``distributed=True`` when calling the pipeline, e.g:
 

--- a/tests/test_branching.py
+++ b/tests/test_branching.py
@@ -17,6 +17,8 @@ def d(input1, input2):
 def double(input):
     return 2*input
 
+def triple(input):
+    return 3*input
 
 class BranchingPipelineTests(unittest.TestCase):
     def test_fork_branching_pipeline(self):
@@ -49,9 +51,9 @@ class BranchingPipelineTests(unittest.TestCase):
         self.assertEqual(out, ([4,5,6,7], [5,6,7,8]))
 
     def test_fork_map(self):
-        p = Pipeline().forkMap(double, double)
+        p = Pipeline().forkMap(double, triple)
         out = p([1,2,3,4])
-        self.assertEqual(out, ([2,4,6,8], [2,4,6,8]))
+        self.assertEqual(out, ([2,4,6,8], [3,6,9,12]))
 
     def test_split(self):
         p = Pipeline().split(double, double)

--- a/tests/test_distrib.py
+++ b/tests/test_distrib.py
@@ -1,6 +1,7 @@
 import unittest
 from atoll import Pipeline
 
+
 def prod(x, y):
     return x*y
 

--- a/tests/test_distrib.py
+++ b/tests/test_distrib.py
@@ -1,47 +1,39 @@
-import os
 import unittest
-from socket import socket
-from unittest import skipIf
 from atoll import Pipeline
-from atoll.distrib import pyspark
-from atoll.config import ZOOKEEPER_HOST
+
+def prod(x, y):
+    return x*y
 
 
-def check_cluster():
-    try:
-        s = socket()
-        ip, port = ZOOKEEPER_HOST.split(':')
-        s.connect(ip, int(port))
-        s.close()
-        return True
-    except OSError:
-        return False
-
-
-@skipIf(not os.environ.get('ATOLL_TEST_DISTRIB', False), 'skipping distributed tests, set env var ATOLL_TEST_DISTRIB=True to run them')
-@skipIf(pyspark is None, 'no pyspark installation found')
-@skipIf(not check_cluster, 'could not reach zookeeper')
 class DistributedTest(unittest.TestCase):
+    def test_to(self):
+        pipeline = Pipeline().map(lambda x: x + 2).to(lambda x: sum(x))
+        result = pipeline([0,1,2,3,4], n_jobs=1, distributed=True)
+        self.assertEqual(result, 20)
+
+        pipeline = Pipeline().to(lambda x: sum(x))
+        result = pipeline([0,1,2,3,4], n_jobs=1, distributed=True)
+        self.assertEqual(result, 10)
 
     def test_map(self):
         pipeline = Pipeline().map(lambda x: x+2).map(lambda x: x*2)
         result = pipeline([0,1,2,3,4], n_jobs=1, distributed=True)
         self.assertEqual(result, [4,6,8,10,12])
 
+    def test_map_tuples(self):
+        pipeline = Pipeline().map(prod).map(lambda x: x+2)
+        result = pipeline([(0,1),(1,2),(2,3),(3,4),(4,5)], n_jobs=1, distributed=True)
+        self.assertEqual(result, [2, 4, 8, 14, 22])
+
     def test_mapValues(self):
-        pipeline = Pipeline().mapValues(lambda x: sum(x))
+        pipeline = Pipeline().mapValues(lambda x: sum(x)).mapValues(lambda x: x*2)
         result = pipeline([('a', [0,1,2]), ('b', [3,4,5])], n_jobs=1, distributed=True)
-        self.assertEqual(result, [('a', 3), ('b', 12)])
+        self.assertEqual(result, [('a', 6), ('b', 24)])
 
-    def test_MapValues_dict(self):
-        pipeline = Pipeline().mapValues(lambda x: x['foo'])
+    def test_mapValues_dict(self):
+        pipeline = Pipeline().mapValues(lambda x: x['foo']).mapValues(lambda x: x*2)
         result = pipeline([('a', {'foo':'yo'}), ('b', {'foo':'bar'})], n_jobs=1, distributed=True)
-        self.assertEqual(result, [('a', 'yo'), ('b', 'bar')])
-
-    def test_mapValues_multiple(self):
-        pipeline = Pipeline().mapValues(lambda x: x['foo']).mapValues(lambda x: len(x))
-        result = pipeline([('a', {'foo':'yo'}), ('b', {'foo':'bar'})], n_jobs=1, distributed=True)
-        self.assertEqual(result, [('a', 2), ('b', 3)])
+        self.assertEqual(result, [('a', 'yoyo'), ('b', 'barbar')])
 
     def test_flatMap(self):
         pipeline = Pipeline().flatMap(lambda x: ['foo', x])
@@ -61,7 +53,7 @@ class DistributedTest(unittest.TestCase):
     def test_reduceByKey(self):
         pipeline = Pipeline().reduceByKey(lambda x, y: x + y)
         result = pipeline([('a', 1), ('a', 2), ('b', 3), ('b', 4)], n_jobs=1, distributed=True)
-        self.assertEqual(result, [('a', 3), ('b', 7)])
+        self.assertEqual(set(result), set([('a', 3), ('b', 7)]))
 
     def test_fork(self):
         p1 = Pipeline().map(lambda x: 2*x)
@@ -70,14 +62,10 @@ class DistributedTest(unittest.TestCase):
         result = pipeline([0,1,2,3,4], n_jobs=1, distributed=True)
         self.assertEqual(result, [[4, 6, 8, 10, 12], [1.0, 1.5, 2.0, 2.5, 3.0]])
 
-    def test_to(self):
-        pipeline = Pipeline().map(lambda x: x + 2).to(lambda x: sum(x))
+    def test_forkMap(self):
+        pipeline = Pipeline().forkMap(lambda x: 2*x, lambda x: x/2)
         result = pipeline([0,1,2,3,4], n_jobs=1, distributed=True)
-        self.assertEqual(result, 20)
-
-        pipeline = Pipeline().to(lambda x: sum(x))
-        result = pipeline([0,1,2,3,4], n_jobs=1, distributed=True)
-        self.assertEqual(result, 10)
+        self.assertEqual(result, [[0, 2, 4, 6, 8], [0, 0.5, 1., 1.5, 2.]])
 
     def test_fork_to(self):
         p1 = Pipeline().map(lambda x: 2*x)
@@ -85,3 +73,13 @@ class DistributedTest(unittest.TestCase):
         pipeline = Pipeline().map(lambda x: x + 2).fork(p1, p2).to(lambda l: [x*y for x,y in zip(*l)])
         result = pipeline([0,1,2,3,4], n_jobs=1, distributed=True)
         self.assertEqual(result, [4.0, 9.0, 16.0, 25.0, 36.0])
+
+    def test_split(self):
+        pipeline = Pipeline().forkMap(lambda x: 2*x, lambda x: x/2).split(lambda x: len(x), lambda x: len(x)*2)
+        result = pipeline([0,1,2,3,4], n_jobs=1, distributed=True)
+        self.assertEqual(result, [5, 10])
+
+    def test_splitMap(self):
+        pipeline = Pipeline().forkMap(lambda x: 2*x, lambda x: x/2).splitMap(lambda x: x+1, lambda x: x+2)
+        result = pipeline([0,1,2,3,4], n_jobs=1, distributed=True)
+        self.assertEqual(result, [[1, 3, 5, 7, 9], [2, 2.5, 3., 3.5, 4.]])


### PR DESCRIPTION
This PR switches distributed computing from Spark, which is not particularly easy to setup, to [`distributed`](https://github.com/dask/distributed), which is much easier to get going with. The goal is to make distributed computing support for `atoll` very easy to get up-and-running.

Additionally, the Spark API did not support all of `atoll`'s pipeline operations; `distributed` makes it easy to implement the `atoll` API in Python so that all of its features are supported.