### PR TITLE
friendlier api error messages

### DIFF
--- a/atoll/exceptions.py
+++ b/atoll/exceptions.py
@@ -1,0 +1,2 @@
+class InvalidInputError(Exception):
+    pass

--- a/atoll/service/errors.py
+++ b/atoll/service/errors.py
@@ -1,4 +1,4 @@
-from flask import Blueprint
+from flask import Blueprint, jsonify
 
 bp = Blueprint('errors', __name__)
 
@@ -10,7 +10,15 @@ def not_found(error):
 
 @bp.app_errorhandler(500)
 def internal_error(error):
-    return 'Internal error', 500
+    """return more helpful info on 500"""
+    data = {
+        'type': type(error).__name__,
+        'message': str(error)
+    }
+    if hasattr(error, 'data'):
+        data['data'] = error.data
+
+    return jsonify(data), 500
 
 
 @bp.app_errorhandler(400)

--- a/coral/__init__.py
+++ b/coral/__init__.py
@@ -65,3 +65,6 @@ coral.register_pipeline('/users/rolling', rolling_score_users)
 
 from .doc import bp as doc_bp
 coral.blueprints.append(doc_bp)
+
+from .errors import bp as err_bp
+coral.blueprints.append(err_bp)

--- a/coral/errors.py
+++ b/coral/errors.py
@@ -1,0 +1,15 @@
+from flask import Blueprint, jsonify
+from .metrics import MetricException
+
+bp = Blueprint('coral_errors', __name__)
+
+
+@bp.app_errorhandler(MetricException)
+def metric_exception(error):
+    resp = {
+        'metric': error.metric,
+        'type': error.type,
+        'message': error.message,
+        'data': error.data
+    }
+    return jsonify(resp), 500

--- a/coral/metrics/__init__.py
+++ b/coral/metrics/__init__.py
@@ -2,11 +2,26 @@ import numpy as np
 from collections import defaultdict
 
 
+class MetricException(Exception):
+    def __init__(self, original_exp, metric, data):
+        message = str(original_exp)
+        super().__init__(message)
+        self.message = message
+        self.metric = metric
+        self.data = data
+        self.type = type(original_exp).__name__
+
+
 def apply_metric(obj, metric):
     """apply a metric to an object.
     returns the object's id with the labeled computed metric"""
-    id = obj['_id']
-    return id, {metric.__name__: metric(obj)}
+    try:
+        id = obj['_id']
+        return id, {metric.__name__: metric(obj)}
+
+    # re-raise as something to catch
+    except Exception as e:
+        raise MetricException(e, metric.__name__, obj)
 
 
 def merge_dicts(d1, d2):

--- a/coral/tests/test_service.py
+++ b/coral/tests/test_service.py
@@ -150,7 +150,6 @@ class ServiceTest(unittest.TestCase):
             'readability_scores': dict
         }
         resp_json = json.loads(resp.data.decode('utf-8'))
-        print(resp_json)
         for result in resp_json['results']['collection']:
             for k, t in expected.items():
                 self.assertTrue(isinstance(result[k], t))
@@ -287,3 +286,30 @@ class ServiceTest(unittest.TestCase):
         for result in resp_json['results']:
             for k, t in expected.items():
                 self.assertTrue(isinstance(result[k], t))
+
+    def test_metric_exception(self):
+        self.app = coral.create_app(**{'TESTING': False})
+        self.client = self.app.test_client()
+
+        data = [
+            self._make_comment(n_replies=2, depth=1),
+            self._make_comment(n_replies=2, depth=1),
+        ]
+
+        # munge the data to incorrect form
+        for comment in data:
+            del comment['_id']
+
+        resp = self._call_pipeline('comments/score', data)
+        self.assertEquals(resp.status_code, 500)
+
+        expected = {
+            'metric': str,
+            'type': str,
+            'message': str,
+            'data': list
+        }
+        resp_json = json.loads(resp.data.decode('utf-8'))
+        for k, t in expected.items():
+            self.assertTrue(isinstance(resp_json[k], t))
+

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -57,3 +57,25 @@ class ServiceTest(unittest.TestCase):
             'results': ['aa', 'bb'],
             'error': None
         }, resp_json)
+
+    def test_invalid_input_exception(self):
+        # create a client with TESTING=False so we get error responses
+        self.app = create_app(**{'TESTING': False})
+        self.app.register_blueprint(pipeline_bp)
+        self.client = self.app.test_client()
+
+        headers = [('Content-Type', 'application/json')]
+        resp = self.client.post('/pipelines/example', data=json.dumps({
+            # munge the data to incorrect form (dict instead of a list)
+            'data': {'foobar': ['AA', 'BB']}
+        }), headers=headers)
+        self.assertEquals(resp.status_code, 500)
+
+        expected = {
+            'type': str,
+            'message': str,
+            'data': dict
+        }
+        resp_json = json.loads(resp.data.decode('utf-8'))
+        for k, t in expected.items():
+            self.assertTrue(isinstance(resp_json[k], t))


### PR DESCRIPTION
This PR adds friendlier API error messages when something fails.

Now on 500 errors, a JSON object is returned by the API, with the following format:

```
{
    'type': str, # the exception type
    'message': str # the error message
}
```

If the exception occurred during execution of a pipeline, this object will additionally have a `data` key with the data the pipeline failed on.

For the Coral Atoll instance, if the exception occurred during a metric, this object will also have a `metric` key with the name of the metric that failed.
